### PR TITLE
[fix] Airflow 환경 변수로 MinIO 엔드포인트와 Twitch 인증 적용

### DIFF
--- a/dev/airflow/scripts/steam/steam_fetch_config.py
+++ b/dev/airflow/scripts/steam/steam_fetch_config.py
@@ -7,7 +7,7 @@ from airflow.models import Variable
 
 
 class Config:
-    MINIO_ENDPOINT = "http://172.30.1.2:9000"
+    MINIO_ENDPOINT = Variable.get("MINIO_ENDPOINT")
     MINIO_ACCESS_KEY = Variable.get("MINIO_ACCESS_KEY")
     MINIO_SECRET_KEY = Variable.get("MINIO_SECRET_KEY")
     MINIO_BUCKET_NAME = Variable.get("GST_BUCKET_NAME")

--- a/dev/airflow/scripts/twitch/twitch_fetch_config.py
+++ b/dev/airflow/scripts/twitch/twitch_fetch_config.py
@@ -19,7 +19,10 @@ from airflow.models import Variable
 
 
 class Config:
-    MINIO_ENDPOINT = "http://172.30.1.2:9000"
+    TWC_CLIENT_ID = Variable.get("TWC_CLIENT_ID")
+    TWC_ACCESS_TOKEN = Variable.get("TWC_ACCESS_TOKEN")
+
+    MINIO_ENDPOINT = Variable.get("MINIO_ENDPOINT")
     MINIO_ACCESS_KEY = Variable.get("MINIO_ACCESS_KEY")
     MINIO_SECRET_KEY = Variable.get("MINIO_SECRET_KEY")
     MINIO_BUCKET_NAME = Variable.get("GST_BUCKET_NAME")


### PR DESCRIPTION
# [fix] Airflow 환경 변수로 MinIO 엔드포인트와 Twitch 인증 적용
### 📑 **작업 개요**
- 하드코딩돼 있던 MinIO 엔드포인트와 Twitch 인증 정보를 Airflow 환경 변수를 통해 관리하도록 변경
- 환경 변수로 변경함으로써 보안성 강화 및 유지보수성 ↑

### 🛠 **주요 변경 사항 (Changes)**
- `MINIO_ENDPOINT`, `TWC_CLIENT_ID`, `TWC_ACCESS_TOKEN` 값을 Airflow의 Variable.get()을 통해 가져오도록 수정
- 기존 하드코딩 값 제거
- 그에 따라 Airflow 환경 변수 등록 및 `config/variables.yaml` 갱신

### ✅ **확인 사항 (Checklist)**
- [x] 타깃 브랜치 확인 `(dev <- fix/airflow-env)`
- [x] 코드가 정상적으로 동작하는지 확인
- [x] Airflow에서 airflow variables set을 사용하여 환경 변수가 정상적으로 등록되었는지 확인
- [x] develop 브랜치로 병합 시 충돌이 발생하지 않는지 확인

### 📌 **추가 정보 (Additional Information)**
- 하드코딩된 커밋 이력 삭제
